### PR TITLE
Solo PR preview comments

### DIFF
--- a/.github/workflows/ci-cd-slaybot.yml
+++ b/.github/workflows/ci-cd-slaybot.yml
@@ -71,7 +71,7 @@ jobs:
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: `This PR has been deployed to Staging! ${ process.env.LINK }`
+            body: `This deploy is ready to be previewed! ${ process.env.LINK }`
           })
 
   deploy-to-production:

--- a/.github/workflows/ci-cd-slaybot.yml
+++ b/.github/workflows/ci-cd-slaybot.yml
@@ -89,14 +89,15 @@ jobs:
             if (data.length === 0) {
               console.log("No comments found");
             }
-            
+          });  
+          
           github.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
             body: `This deploy is ready to be previewed! ${ process.env.LINK }`
           })
-
+   
   deploy-to-production:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-cd-slaybot.yml
+++ b/.github/workflows/ci-cd-slaybot.yml
@@ -75,7 +75,8 @@ jobs:
             console.log(data)
 
             for (var i = 0; i < data.length; i++) { 
-              if (data[i].user.login === "github-actions[bot]" && data[i].body.includes("deploy is ready")) {
+              if (data[i].user.login !== "github-actions[bot]") { continue; } // skip is not printed the a github-actions[bot]
+              if (data[i].body.includes("deploy is ready")) {
                 console.log("You found it")
 
                 github.issues.deleteComment({

--- a/.github/workflows/ci-cd-slaybot.yml
+++ b/.github/workflows/ci-cd-slaybot.yml
@@ -67,7 +67,7 @@ jobs:
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
-          octokit
+          github
           .request(
             `GET /repos/${context.repo.owner}/${context.repo.repo}/issues/${context.issue.number}/comments`
           )
@@ -78,7 +78,7 @@ jobs:
               if (data[i].user.login === "github-actions[bot]" && data[i].body.includes("deploy is ready")) {
                 console.log("You found it")
 
-                octokit.rest.issues.deleteComment({
+                github.issues.deleteComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   comment_id: data[i].id,

--- a/.github/workflows/ci-cd-slaybot.yml
+++ b/.github/workflows/ci-cd-slaybot.yml
@@ -67,6 +67,29 @@ jobs:
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
+          octokit
+          .request(
+            `GET /repos/${context.repo.owner}/${context.repo.repo}/issues/${context.issue.number}/comments`
+          )
+          .then(({ data }) => {
+            console.log(data)
+
+            for (var i = 0; i < data.length; i++) { 
+              if (data[i].user.login === "github-actions[bot]" && data[i].body.includes("deploy is ready")) {
+                console.log("You found it")
+
+                octokit.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: data[i].id,
+                });
+              }
+            }
+
+            if (data.length === 0) {
+              console.log("No comments found");
+            }
+            
           github.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,


### PR DESCRIPTION
# What is this?

The staging GitHub Action flow prints too many comments and this PR adds more context to remove the previous comments. 


# What's next

https://github.com/open-sauced/slaybot/issues/13

Opened the issue to potentially move the script to a new file as mentioned [here](https://github.com/actions/github-script#run-a-separate-file). 

```js
          github
          .request(
            `GET /repos/${context.repo.owner}/${context.repo.repo}/issues/${context.issue.number}/comments`
          )
          .then(({ data }) => {
            console.log(data)
            for (var i = 0; i < data.length; i++) { 
              if (data[i].user.login !== "github-actions[bot]") { continue; } // skip is not printed the a github-actions[bot]
              if (data[i].body.includes("deploy is ready")) {
                console.log("You found it")
                github.issues.deleteComment({
                  owner: context.repo.owner,
                  repo: context.repo.repo,
                  comment_id: data[i].id,
                });
              }
            }
            if (data.length === 0) {
              console.log("No comments found");
            }
          });  
          
          github.issues.createComment({
            issue_number: context.issue.number,
            owner: context.repo.owner,
            repo: context.repo.repo,
            body: `This deploy is ready to be previewed! ${ process.env.LINK }`
          })
```