### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/ci-cd-slaybot.yml
+++ b/.github/workflows/ci-cd-slaybot.yml
@@ -7,120 +7,122 @@ on:
   push:
     branches:
       - main
-  pull_request:
-  workflow_dispatch:
-
+  pull_request: null
+  workflow_dispatch: null
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Cache node_modules 📦
-      uses: actions/cache@v2.1.4
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
-    - name: Set up Node.js version
-      uses: actions/setup-node@v1
-      with:
-        node-version: '14.x'
+      - uses: actions/checkout@v2
+      - name: Cache node_modules 📦
+        uses: actions/cache@v2.1.4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Set up Node.js version
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+          cache: npm
 
-    - name: npm install (no build or test)
-      run: |
-        npm install
+      - name: npm install (no build or test)
+        run: |
+          npm install
 
-    - name: Upload artifact for deployment job
-      uses: actions/upload-artifact@v2
-      with:
-        name: node-app
-        path: .
-  
+      - name: Upload artifact for deployment job
+        uses: actions/upload-artifact@v2
+        with:
+          name: node-app
+          path: .
+
   deploy-staging:
     if: github.event_name == 'pull_request' && github.event.action != 'closed'
     runs-on: ubuntu-latest
     needs: build
     environment:
-      name: 'staging'
+      name: "staging"
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
 
     steps:
-    - name: Download artifact from build job
-      uses: actions/download-artifact@v2
-      with:
-        name: node-app
+      - name: Download artifact from build job
+        uses: actions/download-artifact@v2
+        with:
+          name: node-app
 
-    - name: 'Deploy to Azure Web App'
-      id: deploy-to-webapp
-      uses: azure/webapps-deploy@v2
-      with:
-        app-name: 'slaybot'
-        slot-name: 'staging'
-        publish-profile: ${{ secrets.AZURE_STAGING_PROFILE }}
-        
-    - name: Comment on the PR
-      uses: actions/github-script@v3
-      env:
-        LINK: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
-      with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          github
-          .request(
-            `GET /repos/${context.repo.owner}/${context.repo.repo}/issues/${context.issue.number}/comments`
-          )
-          .then(({ data }) => {
-            console.log(data)
+      - name: "Deploy to Azure Web App"
+        id: deploy-to-webapp
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: "slaybot"
+          slot-name: "staging"
+          publish-profile: ${{ secrets.AZURE_STAGING_PROFILE }}
 
-            for (var i = 0; i < data.length; i++) { 
-              if (data[i].user.login !== "github-actions[bot]") { continue; } // skip is not printed by the github-actions[bot]
-              if (data[i].body.includes("deploy is ready")) {
-                console.log("You found it")
+      - name: Comment on the PR
+        uses: actions/github-script@v3
+        env:
+          LINK: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github
+            .request(
+              `GET /repos/${context.repo.owner}/${context.repo.repo}/issues/${context.issue.number}/comments`
+            )
+            .then(({ data }) => {
+              console.log(data)
 
-                github.issues.deleteComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: data[i].id,
-                });
+              for (var i = 0; i < data.length; i++) { 
+                if (data[i].user.login !== "github-actions[bot]") { continue; } // skip is not printed by the github-actions[bot]
+                if (data[i].body.includes("deploy is ready")) {
+                  console.log("You found it")
+
+                  github.issues.deleteComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: data[i].id,
+                  });
+                }
               }
-            }
 
-            if (data.length === 0) {
-              console.log("No comments found");
-            }
-          });  
-          
-          github.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: `This deploy is ready to be previewed! ${ process.env.LINK }`
-          })
-   
+              if (data.length === 0) {
+                console.log("No comments found");
+              }
+            });  
+
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `This deploy is ready to be previewed! ${ process.env.LINK }`
+            })
+
   deploy-to-production:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: build
     environment:
-      name: 'production'
+      name: "production"
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
 
     steps:
-    - name: Download artifact from build job
-      uses: actions/download-artifact@v2
-      with:
-        name: node-app
+      - name: Download artifact from build job
+        uses: actions/download-artifact@v2
+        with:
+          name: node-app
 
-    - name: 'Deploy to Azure Web App'
-      id: deploy-to-webapp
-      uses: azure/webapps-deploy@v2
-      with:
-        app-name: 'slaybot'
-        slot-name: 'production'
-        publish-profile: ${{ secrets.AzureAppService_PublishProfile_50c39f8bd8d64f34a6e16c058392e725 }}
-      
+      - name: "Deploy to Azure Web App"
+        id: deploy-to-webapp
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: "slaybot"
+          slot-name: "production"
+          publish-profile: ${{
+            secrets.AzureAppService_PublishProfile_50c39f8bd8d64f34a6e16c058392e725
+            }}
+
   update_draft_release:
     name: 📝 Update release notes
     if: github.event_name == 'push'


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
